### PR TITLE
UDP service configuration

### DIFF
--- a/jobs/influxdb/spec
+++ b/jobs/influxdb/spec
@@ -23,3 +23,10 @@ properties:
   influxdb.replication:
     default: "1"
     description: "default replication count for database"
+
+  influxdb.udp.enabled:
+    default: "false"
+    description: "enable udp service"
+  influxdb.udp.bind_address:
+    default: ":8089"
+    description: "udp service bind address"

--- a/jobs/influxdb/templates/influxdb.conf.erb
+++ b/jobs/influxdb/templates/influxdb.conf.erb
@@ -108,9 +108,9 @@ join = ""
   log-point-errors = true
 
 [[udp]]
-  enabled = false
-  bind-address = ":8089"
-  database = "udp"
+  enabled = <%= p("influxdb.udp.enabled") %>
+  bind-address = "<%= p("influxdb.udp.bind_address") %>"
+  database = "<%= p("influxdb.database") %>"
   retention-policy = ""
   batch-size = 5000
   batch-pending = 10


### PR DESCRIPTION
This leaves the default behavior alone (udp service disabled) but allows it to be enabled when included by other releases.
