### PR TITLE
Add a database name to the influxdb properties.

### DIFF
--- a/manifests/bosh-lite.yml
+++ b/manifests/bosh-lite.yml
@@ -22,6 +22,7 @@ jobs:
 properties:
   influxdb:
     ips: [10.244.7.6]
+    database: test
 
 networks:
 - name: warden-net


### PR DESCRIPTION
Previously, we were encountering the following error when deploying to bosh lite:

```
Error 100: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'influxdb'. Errors are:
     - Unable to render templates for job 'influxdb'. Errors are:
       - Error filling in template 'influxd_ctl.erb' (line 138: Can't find property '["influxdb.database"]')
       - Error filling in template 'influxdb.conf.erb' (line 113: Can't find property '["influxdb.database"]')
```

Adding this property fixes the error.

Signed-off-by: Brandon Shroyer bshroyer@pivotal.io
