### PR TITLE
Add support for authentication

### DIFF
--- a/jobs/influxdb/spec
+++ b/jobs/influxdb/spec
@@ -24,6 +24,10 @@ properties:
     default: "1"
     description: "default replication count for database"
 
+  influxdb.http.auth_enabled:
+    default: "false"
+    description: "Set to `true` to enable authentication. Warning: All commands can be executed without a user otherwise."
+
   influxdb.udp.enabled:
     default: "false"
     description: "enable udp service"

--- a/jobs/influxdb/templates/influxdb.conf.erb
+++ b/jobs/influxdb/templates/influxdb.conf.erb
@@ -60,7 +60,7 @@ join = ""
 [http]
   enabled = true
   bind-address = ":8086"
-  auth-enabled = false
+  auth-enabled = <%= p("influxdb.http.auth_enabled") %>
   log-enabled = true
   write-tracing = false
   pprof-enabled = false

--- a/src/bootstrapper/src/bootstrapper/main.go
+++ b/src/bootstrapper/src/bootstrapper/main.go
@@ -10,6 +10,7 @@ import (
 )
 
 func main() {
+	fmt.Println("Running bootstrap")
 	influxUrl := flag.String("influxUrl", "http://localhost:8086", "influx endpoint")
 	influxUser := flag.String("user", "root", "influx user")
 	influxPassword := flag.String("password", "root", "influx user's password")
@@ -34,6 +35,11 @@ func main() {
 	dbClient, err := client.NewClient(influxConfig)
 	if err != nil {
 		panic(fmt.Sprintf("Error connecting to Influx DB: %s", err))
+	}
+
+	_, err = dbClient.Query(client.Query{Command: fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s' WITH ALL PRIVILEGES", *influxUser, *influxPassword)})
+	if err != nil {
+		panic(fmt.Sprintf("Error creating user. Original error: %s", err))
 	}
 
 	_, err = dbClient.Query(client.Query{Command: fmt.Sprintf("create database %s", *databaseName)})


### PR DESCRIPTION
This allows to use http basic authentication with the deployed influxdb. To avoid breaking existing deployments, the `auth_enabled` parameter is set to "false" by default.